### PR TITLE
Translate link label in overview

### DIFF
--- a/ch02_overview.adoc
+++ b/ch02_overview.adoc
@@ -229,7 +229,7 @@ Infine, per fare in modo che la transazione venga elaborata dalla rete in tempi 
 [[transaction-alice-url]]
 [TIP]
 ====
-View the https://oreil.ly/GwBq1[transaction from Alice to Bob's Store].
+Visualizza la https://oreil.ly/GwBq1[transazione di Alice al negozio di Bob].
 ====
 
 ==== Aggiungere la Transazione alla Blockchain


### PR DESCRIPTION
## Summary
- translate the label for Alice's transaction link into Italian

## Testing
- `tools/check` *(fails: asciidoctor not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7f26be94832ca2ddc5d71b1e648e