### PR TITLE
Fix Italian translation in BIP21 example

### DIFF
--- a/ch02_overview.adoc
+++ b/ch02_overview.adoc
@@ -60,12 +60,12 @@ bitcoin:bc1qk2g6u8p4qm2s2lh3gts5cpt2mrv5skcuu7u3e4?amount=0.01577764&
 label=Bob%27s%20Store&
 message=Purchase%20at%20Bob%27s%20Store
 
-Components of the URI
+Elementi dell'URI
 
-A Bitcoin address: "bc1qk2g6u8p4qm2s2lh3gts5cpt2mrv5skcuu7u3e4"
-The payment amount: "0.01577764"
-A label for the recipient address: "Bob's Store"
-A description for the payment: "Purchase at Bob's Store"
+Un indirizzo Bitcoin: "bc1qk2g6u8p4qm2s2lh3gts5cpt2mrv5skcuu7u3e4"
+L'importo del pagamento: "0.01577764"
+Un'etichetta per l'indirizzo del destinatario: "Bob's Store"
+Una descrizione del pagamento: "Purchase at Bob's Store"
 ----
 
 [TIP]


### PR DESCRIPTION
## Summary
- translate heading and bullet details for the BIP21 URI example

## Testing
- `tools/check` *(fails: asciidoctor not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7ef765c0832ca646117801dd79e6